### PR TITLE
Use `lapply()` rather than `sapply()`

### DIFF
--- a/R/n.extrema.R
+++ b/R/n.extrema.R
@@ -74,7 +74,7 @@ n.extrema <- function(xy, id = NULL, use.names = TRUE,
   if(lid == length(xy)){
     idfactor <- factor(id, levels=unique(id))
     s        <- split(xy, idfactor)
-    xy       <- unlist((sapply(s,function(x) append(x, NA))), use.names = F)
+    xy       <- unlist(lapply(s,function(x) append(x, NA)), use.names = F)
     has_id   <- T
   } else if(lid != 0) {
     stop("'id' should be NULL or of same length than 'xy' (", length(xy), ")")


### PR DESCRIPTION
dplyr 1.1.0 is on its way to CRAN right now.

The checks run by CRAN noticed that DecomposeR is broken by this dplyr release, and it somehow slipped through our own reverse dependency checks.

`dplyr::last()` will now return the last _row_ of matrices rather than the last _value_, and this causes issues in your package. It seems like you may have wanted to use `lapply()` rather than `sapply()` here, because `sapply()` creates an array and I think you just wanted a vector.